### PR TITLE
Center the taskbar items

### DIFF
--- a/src/components/Desktop/desktop.module.scss
+++ b/src/components/Desktop/desktop.module.scss
@@ -48,7 +48,10 @@ $bar-height: 3.4rem;
 	gap: 0.5rem;
 	height: $bar-height;
 	align-items: center;
-	justify-content: center;
+
+	@include from(large) {
+		justify-content: center;
+	}
 }
 
 .enrise,

--- a/src/components/Desktop/desktop.module.scss
+++ b/src/components/Desktop/desktop.module.scss
@@ -42,13 +42,13 @@ $bar-height: 3.4rem;
 }
 
 .container {
-	max-width: 72rem;
 	margin: 0 auto;
 	display: flex;
 	flex-direction: row;
 	gap: 0.5rem;
 	height: $bar-height;
 	align-items: center;
+	justify-content: center;
 }
 
 .enrise,


### PR DESCRIPTION
# What

The taskbar items are centered on your screen.
Before this change they were left aligned in a wrapper of 72rem wide, which made it that they were visibly aligned slightly to the left of your monitor.

New situation:
![image](https://github.com/user-attachments/assets/1ad1451e-5e3c-4db1-b90c-90046032e693)


## Why

This makes the alignment nicer than before, now everything ties together nicely instead of having buttons being misaligned with the rest of the application.

This is more of a Windows 11 style approach, personally I would have gone for the traditional Windows 98/7/10 style by left aligning them, but I'm a traditional desktop guy still running XFCE :see_no_evil: .

At any rate, they are nicely aligned now, and the responsiveness / behaviour on smaller screens is still exactly identical as before.
