### PR TITLE
Configure NPM to use legacy peer deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# npm config
+.npmrc

--- a/Taskfile
+++ b/Taskfile
@@ -19,6 +19,7 @@ function banner {
 # =========================================================
 
 function task:init { ## Set up the project for local development
+	project:npm-config
 	project:git-config
 	task:update
 	task:help
@@ -49,6 +50,12 @@ function project:checkout-pr {
 function project:install-dependencies {
 	title "Installing dependencies"
 	npm install
+}
+
+function project:npm-config {
+	title "Configuring NPM"
+	npm config --location=project set legacy-peer-deps=true \
+		&& echo -e "All ${GREEN}good${RESET}."
 }
 
 function project:git-config {


### PR DESCRIPTION
# What

When starting the project, NPM is configured to use legacy peer deps.

## Why

Because we are running Next 19 which is still in beta, NPM often does not want to install the depependencies correctly. Configuring NPM to allow legacy peer deps solves this for now.

This can probably be removed again after Next 19 is released.