### PR TITLE
Bump actions/checkout from 2 to 4

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -10,7 +10,7 @@ jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -10,7 +10,7 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
# What

This PR bumps the repository checkout to v4

## Why

v2 is deprecated: https://github.com/actions/checkout
