### PR TITLE
Fix color definitions

### DIFF
--- a/src/components/Generator/GeneredTaskfile/taskfile-base.sh
+++ b/src/components/Generator/GeneredTaskfile/taskfile-base.sh
@@ -40,11 +40,11 @@ function project:update {
 
 set -eo pipefail
 
-BLUE=$(printf '\\033[36m')
-YELLOW=$(printf '\\033[33m')
-RED=$(printf '\\033[31m')
-GREEN=$(printf '\\033[32m')
-RESET=$(printf '\\033[0m')
+BLUE=$(printf '\033[36m')
+YELLOW=$(printf '\033[33m')
+RED=$(printf '\033[31m')
+GREEN=$(printf '\033[32m')
+RESET=$(printf '\033[0m')
 
 [[globals]]
 


### PR DESCRIPTION
# What
Removed the double `/` in the color definitions.


## Why

The color definitions are currently not being set correctly, resulting in weird output. This PR replaces the double `//` with a single `/`, fixing the issue.
![image](https://github.com/user-attachments/assets/2271eb87-45b8-47c6-b4e0-dd961aa5ab2c)
