### PR TITLE
Add task auto-completion with zsh to the Taskfile setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ using the double `##` comments you've learned about above. Now it's clear how yo
 
 # Auto-completion
 
-Autocompletion works when you use `zsh` with `oh-my-zsh`. Create the following file in your oh-my-zsh directory
+Autocompletion works when you use `zsh` and `oh-my-zsh`. Create the following file in your oh-my-zsh directory
 `~/.oh-my-zsh/completions/_task.zsh`:
 
 ```shell
@@ -81,9 +81,6 @@ _task "$@"
 ```
 
 Now after running `task shorthand`, your `task` commands will get autocompleted.
-
-**Note:** if your task name contains `:` characters, the autocomplete functionality will break. Replace the `:`
-character in your task names to prevent this.
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Generate your own Taskfile at [taskfile.sh](https://taskfile.sh).
 - Easy to understand and maintain
 - Automatically generated list of available task
 
-## How does it work?
+# How does it work?
 
 Taskfiles are simple bash scripts, but an easy-to-read function format. There are some things that we need to explain
 for our Taskfile setup. It all starts with a `Taskfile`. Download your `Taskfile` from
 [taskfile.sh](https://taskfile.sh) and save it. Make sure the Taskfile is executable: `chmod +x ./Taskfile`. You can now
 run `./Taskfile` in your terminal.
 
-### Tasks
+## Tasks
 
 A task is defined by creating a function that starts with `task:`. This defines a task that can be triggered by running
 the `./Taskfile`. Right next to the task, you should add a task definition with two hashes. This will let the
@@ -40,7 +40,7 @@ function task:example { ## Show some example text
 In a task you can call other functions, and run all tooling you desire. Now running `./Taskfile example` will execute
 the new task.
 
-### Sections
+## Sections
 
 To group multiple tasks, sections can be created in your Taskfile. A section is created by creating a comment line with
 a double hashtag like so:
@@ -51,17 +51,46 @@ a double hashtag like so:
 
 Lines with only a single `#` will not appear as section in `task:help` and can be seen as plain comments.
 
-### Help command
+## Help command
 
 Running `./Taskfile help`, the `task:help` function is triggered. This task will list all available sections and tasks
 using the double `##` comments you've learned about above. Now it's clear how you can run any other task!
 
-## Credits
+# Auto-completion
+
+Autocompletion works when you use `zsh` with `oh-my-zsh`. Create the following file in your oh-my-zsh directory
+`~/.oh-my-zsh/completions/_task.zsh`:
+
+```shell
+#compdef task
+
+_task() {
+	local -a commands
+	local tasks=$(task comp_targets)
+
+	while IFS= read -r line; do
+		if [[ -n "$line" ]]; then
+			commands+=("$line")
+		fi
+	done <<< "$tasks"
+
+	_describe -t commands 'task commands' commands
+}
+
+_task "$@"
+```
+
+Now after running `task shorthand`, your `task` commands will get autocompleted.
+
+**Note:** if your task name contains `:` characters, the autocomplete functionality will break. Replace the `:`
+character in your task names to prevent this.
+
+# Credits
 
 This Taskfile setup is based on [Adrian Cooney's Taskfile](https://github.com/adriancooney/Taskfile) and is widely
 adopted by [Enrise](https://enrise.com) in our modified flavour.
 
-## Contributors
+# Contributors
 
 A big thanks to all the contributors of Taskfile!
 

--- a/Taskfile
+++ b/Taskfile
@@ -130,7 +130,7 @@ function task:help { ## Show all available tasks
 		{printf "\033[33m%-34s\033[0m %s\n", $1, $2}' $0 |\
 		sed -E "s/[#]{2,}[ ]*/${RESET}/g" |\
 		sed -E "s/function task:*/  /g"
-	echo -e "\n${BLUE}Usage:${RESET} $0 ${YELLOW}<task>${RESET} <args>"
+	echo -e "\n${BLUE}Usage:${RESET} ./Taskfile ${YELLOW}<task>${RESET} <args>"
 }
 
 function task:shorthand { ## Create CLI shorthand task instead of ./Taskfile

--- a/bin/task
+++ b/bin/task
@@ -10,19 +10,32 @@ RED=$(printf '\033[31m')
 RESET=$(printf '\033[0m')
 
 while [ -d $CURRENT_DIR ] && [ $CURRENT_DIR != '/' ]; do
-	if [ -f ./Taskfile ];
-	then
-		./Taskfile $@
-		exit $?
-	elif [ -f ./Makefile ]; then
-		echo -e "${RED}Found a Makefile instead of a Taskfile...${RESET}\n"
-		make $@
-		exit $?
-	else
-		cd ../
-		CURRENT_DIR=$(pwd)
+	if [[ -e "${CURRENT_DIR}/Taskfile" ]]; then
+		TASKFILE="${CURRENT_DIR}/Taskfile"
+		break
 	fi
+
+	if [[ -e "${CURRENT_DIR}/Makefile" ]]; then
+		echo -e "Found a ${RED}Makefile${RESET} instead of a Taskfile...\n"
+		make --directory=$CURRENT_DIR $@
+		exit $?
+	fi
+
+	CURRENT_DIR=$(dirname $CURRENT_DIR)
 done
 
-echo -e "${RED}ERROR: ${RESET}./Taskfile not found in the current or parent directories."
-exit 1
+if [[ -z "$TASKFILE" ]]; then
+	echo -e "${RED}ERROR: ${RESET}./Taskfile not found in the current or parent directories."
+	exit 1
+fi
+
+if [[ $1 == 'comp_targets' ]]; then
+	awk 'BEGIN {FS = " { [#][#][ ]?"} /^function task([a-zA-Z_-]*:?.*)(\{ )?[#][#][ ]?/ {printf "%s:%s\n", $1, $2}' \
+		"$TASKFILE" \
+		| sed -E 's/[#]{2,}[ ]*//g' \
+		| sed -E 's/function task://g'
+	exit 1
+fi
+
+$TASKFILE $@
+exit $?

--- a/bin/task
+++ b/bin/task
@@ -30,8 +30,7 @@ if [[ -z "$TASKFILE" ]]; then
 fi
 
 if [[ $1 == 'comp_targets' ]]; then
-	awk 'BEGIN {FS = " { [#][#][ ]?"} /^function task([a-zA-Z_-]*:?.*)(\{ )?[#][#][ ]?/ {printf "%s:%s\n", $1, $2}' \
-		"$TASKFILE" \
+	awk 'BEGIN {FS = " { [#][#][ ]?"} /^function task:(.*)[#][#][ ]?/ {printf "%s:%s\n", $1, $2}' "$TASKFILE" \
 		| sed -E 's/[#]{2,}[ ]*//g' \
 		| sed -E 's/function task://g'
 	exit 1

--- a/bin/task
+++ b/bin/task
@@ -30,9 +30,10 @@ if [[ -z "$TASKFILE" ]]; then
 fi
 
 if [[ $1 == 'comp_targets' ]]; then
-	awk 'BEGIN {FS = " { [#][#][ ]?"} /^function task:(.*)[#][#][ ]?/ {printf "%s:%s\n", $1, $2}' "$TASKFILE" \
+	awk 'BEGIN {FS = " { [#][#][ ]?"} /^function task:(.*)[#][#][ ]?/ {gsub(/:/, "\\:", $1); printf "%s:%s\n", $1, $2}' \
+		"$TASKFILE" \
 		| sed -E 's/[#]{2,}[ ]*//g' \
-		| sed -E 's/function task://g'
+		| sed -E 's/function task\\://g'
 	exit 1
 fi
 

--- a/src/components/Generator/GeneredTaskfile/taskfile-base.sh
+++ b/src/components/Generator/GeneredTaskfile/taskfile-base.sh
@@ -58,7 +58,7 @@ function task:help { ## Show all available tasks
 		{printf "\033[33m%-34s\033[0m %s\n", $1, $2}' $0 |\
 		sed -E "s/[#]{2,}[ ]*/${RESET}/g" |\
 		sed -E "s/function task:*/  /g"
-	echo -e "\n${BLUE}Usage:${RESET} $0 ${YELLOW}<task>${RESET} <args>"
+	echo -e "\n${BLUE}Usage:${RESET} ./Taskfile ${YELLOW}<task>${RESET} <args>"
 }
 
 function task:shorthand { ## Create CLI shorthand task instead of ./Taskfile

--- a/src/components/Generator/generator.module.scss
+++ b/src/components/Generator/generator.module.scss
@@ -31,7 +31,6 @@
 	@include from(large) {
 		width: 25rem;
 		align-self: flex-start;
-		max-height: none;
 	}
 }
 


### PR DESCRIPTION
# What

Add task auto-completion to the Taskfile setup when you use `zsh` with `oh-my-zsh`.

## Why

@eXistenZNL and @GreenTreeLeaf have shown an auto-completion setup for Taskfiles. Let's add a generalized way of achieving this! :partying_face: 
