### PR TITLE
Show banner only for help command

### DIFF
--- a/Taskfile
+++ b/Taskfile
@@ -125,6 +125,7 @@ function title {
 }
 
 function task:help { ## Show all available tasks
+	banner
 	title "Available tasks"
 	awk 'BEGIN {FS = " { [#][#][ ]?"} /^([a-zA-Z_-]*:?.*)(\{ )?[#][#][ ]?/ \
 		{printf "\033[33m%-34s\033[0m %s\n", $1, $2}' $0 |\
@@ -141,7 +142,6 @@ function task:shorthand { ## Create CLI shorthand task instead of ./Taskfile
 	echo -e "${BLUE}You can now use:${RESET} task ${YELLOW}<task>${RESET} <arguments>"
 }
 
-banner
 if [[ ! "$(declare -F task:${@-help})" ]]; then
 	title "Task not found"
 	echo -e "Task ${YELLOW}$1${RESET} doesn't exist."

--- a/src/components/Generator/GeneredTaskfile/taskfile-base.sh
+++ b/src/components/Generator/GeneredTaskfile/taskfile-base.sh
@@ -53,6 +53,7 @@ function title {
 }
 
 function task:help { ## Show all available tasks
+	banner
 	title "Available tasks"
 	awk 'BEGIN {FS = " { [#][#][ ]?"} /^([a-zA-Z_-]*:?.*)(\{ )?[#][#][ ]?/ \
 		{printf "\033[33m%-34s\033[0m %s\n", $1, $2}' $0 |\
@@ -69,7 +70,6 @@ function task:shorthand { ## Create CLI shorthand task instead of ./Taskfile
 	echo -e "${BLUE}You can now use:${RESET} task ${YELLOW}<task>${RESET} <args>"
 }
 
-banner
 if [[ ! "$(declare -F task:${@-help})" ]]; then
 	title "Task not found"
 	echo -e "Task ${RED}$1${RESET} doesn't exist."


### PR DESCRIPTION
# What

The banner is now only shown when the help command is ran

## Why

Developers use more tools like claude code and opencode. When these tools work with our project they will ofcourse run our taskfile commands. This change reduces the amount of tokens needed for LLM's to process output from taskfiles.
